### PR TITLE
Change render order of entities

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -118,14 +118,14 @@ var Engine = (function(global) {
     function renderEntities() {
         var allEnemies = level.enemies;
         var allGems = level.gems;
-        allEnemies.forEach(function(enemy) {
-            enemy.render();
-        });
 
-        level.player.render();
         level.star.render();
         allGems.forEach(function(gem) {
             gem.render();
+        });
+        level.player.render();
+        allEnemies.forEach(function(enemy) {
+            enemy.render();
         });
     }
 


### PR DESCRIPTION
Gems and stars were rendering over top of player and enemies. I dropped the function calls to render the player and enemies below the function calls to render the star and gems to fix this.
